### PR TITLE
chore: Pull latest image always for now

### DIFF
--- a/charts/superset/values.yaml
+++ b/charts/superset/values.yaml
@@ -158,10 +158,12 @@ configMountPath: "/app/pythonpath"
 
 extraConfigMountPath: "/app/configs"
 
+# only tag=latest is available at the moment
+# TODO: should ideally be stamped tag with pullPolicy=IfNotPresent
 image:
   repository: apache/superset
   tag: latest
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 imagePullSecrets: []
 


### PR DESCRIPTION
Superset makes available only the Docker image tagged "latest" for the time being. Setting to update always for the moment so that the image structure matches what is expected by the Kubernetes config (templates).

Symptom of not doing this is the fact that the current, updated config expects a `/usr/bin/run-server.sh` vs. what was in the previous image of `/usr/bin/docker-entrypoint.sh`.