### PR TITLE
Add persistence to neo4j for amundsen

### DIFF
--- a/charts/amundsen/values.yaml
+++ b/charts/amundsen/values.yaml
@@ -317,12 +317,10 @@ neo4j:
   ##
   ## neo4j.persistence -- Neo4j persistence. Turn this on to keep your data between pod crashes, etc. This is also needed for backups.
   ##
-  persistence: {}
-  #  storageClass: gp2
-  #  size: 10Gi
-  #  accessMode: ReadWriteMany
-  #  efs:
-  #    dns:
+  persistence:
+    storageClass: gp2
+    size: 10Gi
+    accessMode: ReadWriteOnce
 
   ##
   ## neo4j.backup -- If enabled is set to true, make sure and set the s3 path as well.


### PR DESCRIPTION
Because neo4j is not defaulted to be persistent, everytime the neo4j pod restarts, all data is lost. Adding persistence so that even when we do upgrades, the data will not be lost. Default storage is EBS.