### PR TITLE
fix: CDI-1876 - Add nodeselector

### DIFF
--- a/charts/tonic/templates/tonic-notifications-deployment.yaml
+++ b/charts/tonic/templates/tonic-notifications-deployment.yaml
@@ -120,4 +120,6 @@ spec:
       - name: tonicai-build-writer-pull-secret
       serviceAccountName: {{ template "tonic.serviceAccountName" . }}
       volumes: null
+      nodeSelector:
+        kubernetes.io/arch: amd64
 status: {}

--- a/charts/tonic/templates/tonic-oracle-helper-deployment.yaml
+++ b/charts/tonic/templates/tonic-oracle-helper-deployment.yaml
@@ -66,6 +66,8 @@ spec:
       - name: tonicai-build-writer-pull-secret
       serviceAccountName: {{ template "tonic.serviceAccountName" . }}
       volumes: null
+      nodeSelector:
+        kubernetes.io/arch: amd64
 status: {}
 {{- end }}
 {{- end }}

--- a/charts/tonic/templates/tonic-pii-detection-deployment.yaml
+++ b/charts/tonic/templates/tonic-pii-detection-deployment.yaml
@@ -68,3 +68,5 @@ spec:
       imagePullSecrets:
       - name: tonicai-build-writer-pull-secret
       serviceAccountName: {{ template "tonic.serviceAccountName" . }}
+      nodeSelector:
+        kubernetes.io/arch: amd64

--- a/charts/tonic/templates/tonic-pyml-deployment.yaml
+++ b/charts/tonic/templates/tonic-pyml-deployment.yaml
@@ -68,3 +68,5 @@ spec:
       imagePullSecrets:
       - name: tonicai-build-writer-pull-secret
       serviceAccountName: ""
+      nodeSelector:
+        kubernetes.io/arch: amd64

--- a/charts/tonic/templates/tonic-web-server-deployment.yaml
+++ b/charts/tonic/templates/tonic-web-server-deployment.yaml
@@ -168,4 +168,6 @@ spec:
       imagePullSecrets:
       - name: tonicai-build-writer-pull-secret
       volumes: null
+      nodeSelector:
+        kubernetes.io/arch: amd64
 status: {}

--- a/charts/tonic/templates/tonic-worker-deployment.yaml
+++ b/charts/tonic/templates/tonic-worker-deployment.yaml
@@ -131,4 +131,6 @@ spec:
       imagePullSecrets:
       - name: tonicai-build-writer-pull-secret
       serviceAccountName: {{ template "tonic.serviceAccountName" . }}
+      nodeSelector:
+        kubernetes.io/arch: amd64
 status: {}


### PR DESCRIPTION
Deployments were failing on some eks clusters depending on node availability and the introduction of ARM