### PR TITLE
fix: CDI-2403 - change tonic textual api traffic ports

### DIFF
--- a/charts/tonic-textual/Chart.yaml
+++ b/charts/tonic-textual/Chart.yaml
@@ -3,6 +3,6 @@ name: solar
 description: A Helm chart for Solar (Tonic Textual)
 type: application
 
-version: "1.0.1"
+version: "1.0.2"
 
 appVersion: "8"

--- a/charts/tonic-textual/values.yaml
+++ b/charts/tonic-textual/values.yaml
@@ -30,8 +30,8 @@ solar_api_server:
     # GCP: https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer
   ports:
     httpsOnly: true
-    https: 443
-    http: 80
+    https: 8443
+    http: 8080
 solar_worker:
   # numberOfWorkers will determine how many worker containers are deployed when installing the helm chart.
   numberOfWorkers: 1


### PR DESCRIPTION
Based on feedback from Tonic engineers, it looks like traffic on port 80 for the api server is blocked. Changing port to text theory