### PR TITLE
fix: CDI-3006 - Add AWS creds to env vars for Tonic worker pods too

### DIFF
--- a/charts/tonic/Chart.yaml
+++ b/charts/tonic/Chart.yaml
@@ -3,6 +3,6 @@ name: tonic
 description: A Helm chart for Tonic and EKS
 type: application
 
-version: "2.1.2"
+version: "2.1.3"
 
 appVersion: "130"

--- a/charts/tonic/templates/tonic-worker-deployment.yaml
+++ b/charts/tonic/templates/tonic-worker-deployment.yaml
@@ -138,6 +138,24 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: instance-profile-secret
+                  key: TONIC_AWS_ACCESS_KEY_ID
+                  optional: false
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: instance-profile-secret
+                  key: TONIC_AWS_SECRET_ACCESS_KEY
+                  optional: false
+            - name: AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: instance-profile-secret
+                  key: TONIC_AWS_REGION
+                  optional: false            
           image: {{ $image }}:{{ .Values.tonicVersion | default "latest" }}
           imagePullPolicy: Always
           name: tonic-worker


### PR DESCRIPTION
Vendor got back to us and said the worker pods need these env vars, too