### PR TITLE
fix: CDI-2978 Remove nvidia/gpu from node selector

### DIFF
--- a/charts/tonic-textual/templates/solar-ml-deployment.yaml
+++ b/charts/tonic-textual/templates/solar-ml-deployment.yaml
@@ -164,4 +164,3 @@ spec:
       nodeSelector:
         kubernetes.io/arch: amd64
         tonic/gpu: "true"
-        nvidia.com/gpu: "true"


### PR DESCRIPTION
From pod logs:
```
0/13 nodes are available: 1 Insufficient nvidia.com/gpu, 10 node(s) didn't match Pod's node affinity/selector, 2 node(s) had untolerated taint {eks.amazonaws.com/compute-type: fargate}. preemption: 0/13 nodes are available: 1 No preemption victims found for incoming pod, 12 Preemption is not helpful for scheduling.
```

Flag is already set here https://github.com/chanzuckerberg/helm-charts/blob/4226f80832f81135b3b3460b7f4f1dc84702dba4/charts/tonic-textual/templates/solar-ml-deployment.yaml#L94, looking for a number